### PR TITLE
Fix localeDateString usage

### DIFF
--- a/docs/labs/ts/21-RouteParameters.md
+++ b/docs/labs/ts/21-RouteParameters.md
@@ -57,7 +57,7 @@ title: 'Lab 21: Route Parameters'
                <p>{project.description}</p>
                <p>Budget : {project.budget}</p>
 
-               <p>Signed: {project.contractSignedOn.toLocaleDateString()}</p>
+               <p>Signed: {new Date(project.contractSignedOn).toLocaleDateString()}</p>
                <p>
                  <mark className="active">
                    {' '}


### PR DESCRIPTION
## Problem
The `localeDateString` function is being used at a string object.

## Solution
Create a Date object to be able to call `localeDateString`.