### PR TITLE
Update 00-VisualStudioCodeSetup.md

### DIFF
--- a/docs/00-VisualStudioCodeSetup.md
+++ b/docs/00-VisualStudioCodeSetup.md
@@ -71,4 +71,3 @@ If you are interested in trying a new font designed for programming.
 
 - [React & JS Snippets](https://marketplace.visualstudio.com/items?itemName=dsznajder.es7-react-js-snippets) OR [Simple React Snippets](https://marketplace.visualstudio.com/items?itemName=burkeholland.simple-react-snippets)
 - [React Documentation Extension](https://marketplace.visualstudio.com/items?itemName=avraammavridis.vsc-react-documentation)
-- [Bracket Pair Colorizer](https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer)


### PR DESCRIPTION
remove the mention and link for bracket colorizer extension, as it is deprecated and the functionality is now natively supported in VS Code.  see https://github.com/CoenraadS/Bracket-Pair-Colorizer-2#-christmas-notice-%EF%B8%8F